### PR TITLE
Update to target just the settings tabs

### DIFF
--- a/vendor/assets/stylesheets/activeadmin_settings.css.scss
+++ b/vendor/assets/stylesheets/activeadmin_settings.css.scss
@@ -48,7 +48,7 @@
   .form_actions { display:none; }
 }
 
-ul.tabs {
+#settings_tabs ul.tabs {
   margin-bottom: 14px;
   overflow: hidden;
 }


### PR DESCRIPTION
Did you mean to target all the AA tabs? If you have drop down menu's in aa the class is ul.tabs.  this line was preventing them from displaying (they got cut off when they reached the title bar) hth.