### PR TITLE
Update picture.rb for Rails 4

### DIFF
--- a/app/models/activeadmin_settings/picture.rb
+++ b/app/models/activeadmin_settings/picture.rb
@@ -65,7 +65,7 @@ module ActiveadminSettings
       include PictureMethods
 
       # Scopes
-      default_scope order('created_at desc')
+      default_scope { order('created_at desc') }
     end
   end
 end


### PR DESCRIPTION
Fix default_scope for use in Rails 4 (Support for calling #default_scope without a block is removed)
