### PR TITLE
added 'admin' prefix to routes

### DIFF
--- a/lib/activeadmin-settings/routing.rb
+++ b/lib/activeadmin-settings/routing.rb
@@ -1,7 +1,7 @@
 module ActionDispatch::Routing
   class Mapper
     def mount_activeadmin_settings
-      scope '/admin', :module => "activeadmin_settings" do
+      scope '/admin', :module => "activeadmin_settings", as: 'admin' do
         scope "redactor" do
           resources :pictures,  :only => [:index, :create]
         end


### PR DESCRIPTION
In order to avoid conflicts, for example if we have model User.